### PR TITLE
CopySteamLibraries.cs    macOS compatability issue

### DIFF
--- a/Assets/Scripts/Editor/CopySteamLibraries.cs
+++ b/Assets/Scripts/Editor/CopySteamLibraries.cs
@@ -29,7 +29,7 @@ namespace Facepunch.Editor
             if ( target == BuildTarget.StandaloneWindows64 )
                 FileUtil.ReplaceFile( "steam_api64.dll", System.IO.Path.GetDirectoryName( pathToBuiltProject ) + "/steam_api64.dll" );
 
-            if ( target == BuildTarget.StandaloneOSX )
+            if ( target == BuildTarget.StandaloneOSXIntel )//need this fix for Unity running on macOS
                 FileUtil.ReplaceFile( "libsteam_api.dylib", System.IO.Path.GetDirectoryName( pathToBuiltProject ) + "/libsteam_api.dylib" );
 
             if ( target == BuildTarget.StandaloneLinux64 || target == BuildTarget.StandaloneLinuxUniversal )


### PR DESCRIPTION
Working in Unity2018.2.17f1 on macOS Sierra I had to change "BuildTarget.StandaloneOSX"  to  "BuildTarget.StandaloneOSXIntel", to avoid getting an error. (Other developers working on Windows platform didn't ever face that issue).